### PR TITLE
update:GET/notes sortの実装

### DIFF
--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -481,7 +481,7 @@ func (r *Repository) GetNotes(ctx context.Context, params GetNotesParams) ([]Get
 				},
 			}
 		default:
-			return nil, fmt.Errorf("invalid sortKey value: %s", params.SortKey)
+			return nil, 0, fmt.Errorf("invalid sortKey value: %s", params.SortKey)
 		}
 	}
 


### PR DESCRIPTION
Sort()にわたす値の型にはSortCombinationCaster()というメソッドが必要なようですが、公式ではそのメソッドが実装されている型がありません。自分で型とメソッドを定義すると動くようになりました。